### PR TITLE
fix: roleName elements with type

### DIFF
--- a/PRS1001-2000/PRS1950Annesley.xml
+++ b/PRS1001-2000/PRS1950Annesley.xml
@@ -43,13 +43,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <listPerson>
             <person sex="1" sameAs="wd:Q5536270">
                <persName xml:id="n1">
-                   <forename>George</forename>
+                  <forename>George</forename>
                   <surname>Annesley</surname>
                </persName>
                <persName type="alt" xml:id="n2">
-                  <roleName>Viscount</roleName>Valentia</persName>
+                  <roleName type="title">Viscount</roleName> Valentia</persName>
                <persName type="alt" xml:id="n3">
-                  <roleName>Lord</roleName> Mountnorris</persName>
+                  <roleName type="title">Lord</roleName> Mountnorris</persName>
                <occupation type="other">traveler</occupation>
             </person>
          </listPerson>

--- a/PRS12001-13000/PRS12827Kasa.xml
+++ b/PRS12001-13000/PRS12827Kasa.xml
@@ -39,14 +39,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <listPerson>
                 <person sex="1">
                     <persName xml:lang="gez" xml:id="n1">ካሣ፡</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1"><roleName>grā getā</roleName> Kāśā</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1"><roleName type="title">grā getā</roleName> Kāśā</persName>
                     <faith type="EOTC"/>
                     <floruit notBefore="1850" notAfter="1900"/>
                 </person>
                 <listRelation>
                     <relation name="saws:isCopierOf" active="PRS12827Kasa" passive="ESsmm001"/>
                 </listRelation>
-            </listPerson><!---->
+            </listPerson>
         </body>
     </text>
 </TEI>


### PR DESCRIPTION
It turned out that the schema requires the roleName element to have an attribute type.
After adding those both remaining files now validate.
Alternatively you could choose to change the requirement in the schema itself (in tei-betamesaheft.rng L14740 ff).
That is up to you.