### PR TITLE
Create PRS13977GabraMasqal.xml

### DIFF
--- a/new/PRS13968Arsanyos.xml
+++ b/new/PRS13968Arsanyos.xml
@@ -47,6 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <person sex="1">
                     <persName xml:lang="gez" xml:id="n1">አርሳንዮስ፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾArsānyos</persName>
+                    <persName xml:lang="gez" xml:id="n2">አርሳኔዎስ</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n2">ʾArsānewos</persName>
                     <faith type="EOTC"/>
                     <floruit when="1728"/>
                 </person>

--- a/new/PRS13977GabraMasqal.xml
+++ b/new/PRS13977GabraMasqal.xml
@@ -13,11 +13,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
-                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
                     <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
-                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Gabra Masqal</persName>
                     <birth/>
                     <death/>
-                    <floruit>1728</floruit>
+                    <floruit when="1728"/>
                 </person>
                 <listRelation>
                     <relation cert="low" name="snap:SonOf" active="PRS13977GabraMasqal" passive="PRS5187Hawarya"/>

--- a/new/PRS13977GabraMasqal.xml
+++ b/new/PRS13977GabraMasqal.xml
@@ -1,0 +1,60 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS13977GabraMasqal" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Gabra Masqal</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-02-07">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ገብረ፡ መስቀል፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Gabra Masqal</persName>
+                    <birth/>
+                    <death/>
+                    <floruit>1728</floruit>
+                </person>
+                <listRelation>
+                    <relation cert="low" name="snap:SonOf" active="PRS13977GabraMasqal" passive="PRS5187Hawarya"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
Created ID for Gabra Masqal who was possibly a son of təʾəzaz Hawarya Krəstos (PRS5187Hawarya). Hawarya Krestos died in a battle in the year 1700. In 1728 the manuscript BMLacq681 mentions Gabra Masqal as a son of Hawarya Krestos. There is a possibility that this Gabra Masqal is the son of the famous Hawarya Krestos, but it is not certain. For this reason I marked the relation with low certainty.