### PR TITLE
Create PRS13990ZawaldaMaryam.xml

### DIFF
--- a/PRS12001-13000/PRS12076ZawaldaMaryam.xml
+++ b/PRS12001-13000/PRS12076ZawaldaMaryam.xml
@@ -55,7 +55,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <floruit notBefore="1700" notAfter="1750">18th century</floruit>
                 </person>
                 <listRelation>
-                    <relation name="saws:isCopierOf" active="PRS12076ZawaldaMaryam" passive="ESamq014 ESqsm001 ESqsm007 ESmr008 ESum042 ESmkl015 ESmkl016"/>
+                    <relation name="saws:isCopierOf" active="PRS12076ZawaldaMaryam" passive="ESamq014 ESqsm001 ESqsm007 ESmr008 ESum042 ESmkl015 ESmkl016 BMLacq810 BMLacq306"/>
+                    <relation name="saws:hasOwned" active="PRS12076ZawaldaMaryam" passive="BMLacq810"></relation>
                 </listRelation>
             </listPerson>
          <!---->

--- a/new/PRS13990ZawaldaMaryam.xml
+++ b/new/PRS13990ZawaldaMaryam.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS13990ZawaldaMaryam" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ዘወልደ፡ ማርያም፡</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-03-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person>
+                    <persName xml:lang="gez" xml:id="n1">ዘወልደ፡ ማርያም፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Zawalda Māryām</persName>
+                    <faith type="EOTC"/>
+                    <birth/>
+                    <death/>
+                    <floruit>19th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="saws:hasOwned" active="PRS13990ZawaldaMaryam" passive="BMLacq810"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS13990ZawaldaMaryam.xml
+++ b/new/PRS13990ZawaldaMaryam.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>ዘወልደ፡ ማርያም፡</title>
+                <title>Zawalda Māryām</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -48,9 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" xml:id="n1">ዘወልደ፡ ማርያም፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Zawalda Māryām</persName>
                     <faith type="EOTC"/>
-                    <birth/>
-                    <death/>
-                    <floruit>19th century</floruit>
+                    <floruit notBefore="1600" notAfter="1900">17th, 18th or 19th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="saws:hasOwned" active="PRS13990ZawaldaMaryam" passive="BMLacq810"/>


### PR DESCRIPTION
The name Zawalda Maryam occurs in some of the prayers rather in the middle of the manuscript for example on f. 12rb. Several persons with the name Zawalda Māryām and a period of activity in the 19th century already exist as for instance PRS11836ZawaldaM or PRS12182ZawaldaM, but I think it would be rather accidental if the owner of this manuscript was indeed one of them and we have no chance to make that certain. For this reason I rather created a new ID.