### PR TITLE
New IDs for GabraHanaCare, KidanaMaryam (owners) and TaklaMaryam (scribe of BMLacq720)

### DIFF
--- a/new/PRS13993GabraHanaCare.xml
+++ b/new/PRS13993GabraHanaCare.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>ገብረ፡ ሐና፡ ቸሬ፡</title>
+                <title>Gabra Ḥannā Čare</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,10 +46,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <listPerson>
                 <person>
                     <persName xml:lang="gez" xml:id="n1">ገብረ፡ ሐና፡ ቸሬ፡</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1">Gabra Ḥanā Čare</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Gabra Ḥannā Čare</persName>
                     <birth/>
                     <death/>
-                    <floruit>19th or 20th century</floruit>
+                    <floruit notBefore="1800" notAfter="1987">19th or 20th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="saws:hasOwned" active="PRS13993GabraHanaCare" passive="BMLacq720"/>

--- a/new/PRS13993GabraHanaCare.xml
+++ b/new/PRS13993GabraHanaCare.xml
@@ -1,0 +1,60 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS13993GabraHanaCare" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ገብረ፡ ሐና፡ ቸሬ፡</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-03-30">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person>
+                    <persName xml:lang="gez" xml:id="n1">ገብረ፡ ሐና፡ ቸሬ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Gabra Ḥanā Čare</persName>
+                    <birth/>
+                    <death/>
+                    <floruit>19th or 20th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="saws:hasOwned" active="PRS13993GabraHanaCare" passive="BMLacq720"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS13994KidanaMaryam.xml
+++ b/new/PRS13994KidanaMaryam.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>ኪዳነ፡ ማርያም፡</title>
+                <title>Kidāna Māryām</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Kidāna Māryām</persName>
                     <birth/>
                     <death/>
-                    <floruit>19th or 20th centuries</floruit>
+                    <floruit notBefore="1800" notAfter="1987">19th or 20th centuries</floruit>
                 </person>
                 <listRelation>
                     <relation name="saws:hasOwned" active="PRS13994KidanaMaryam" passive="BMLacq720"/>

--- a/new/PRS13994KidanaMaryam.xml
+++ b/new/PRS13994KidanaMaryam.xml
@@ -1,0 +1,60 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS13994KidanaMaryam" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ኪዳነ፡ ማርያም፡</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-03-30">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person>
+                    <persName xml:lang="gez" xml:id="n1">ኪዳነ፡ ማርያም፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Kidāna Māryām</persName>
+                    <birth/>
+                    <death/>
+                    <floruit>19th or 20th centuries</floruit>
+                </person>
+                <listRelation>
+                    <relation name="saws:hasOwned" active="PRS13994KidanaMaryam" passive="BMLacq720"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS13995TaklaMaryam.xml
+++ b/new/PRS13995TaklaMaryam.xml
@@ -1,0 +1,60 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS13995TaklaMaryam" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ተክለ፡ ማርያም፡</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-03-30">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person>
+                    <persName xml:lang="gez" xml:id="n1">ተክለ፡ ማርያም፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Takla Māryām</persName>
+                    <birth/>
+                    <death/>
+                    <floruit>19th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="saws:isCopierOf" active="PRS13995TaklaMaryam" passive="BMLacq720"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS13995TaklaMaryam.xml
+++ b/new/PRS13995TaklaMaryam.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>ተክለ፡ ማርያም፡</title>
+                <title>Takla Māryām</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Takla Māryām</persName>
                     <birth/>
                     <death/>
-                    <floruit>19th century</floruit>
+                    <floruit notBefore="1800" notAfter="1899">19th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="saws:isCopierOf" active="PRS13995TaklaMaryam" passive="BMLacq720"/>


### PR DESCRIPTION
I created some new ID for persons that are to be found in BMLacq720. The name Gabra Ḥanā Čare is not attested before in betamaṣaḥəft. The name Kidāna Māryām on the other hand is present a few times, but the relation is to unspecific to identify him or her with an existant PRS-ID. The scribe Takla Māryām is perhaps the same as the one, who wrote EMIP03224 - at least the name is identical, but alas I cannot check, whether it is the same hand, because there are not images available. I do not even have a clue, whether the possible date may allow such a statement, because this is not encoded in the record of EMIP03224.