### PR TITLE
New PRS record for Tanasee1 (no. 14)

### DIFF
--- a/new/PRS14190AsrataMaryam.xml
+++ b/new/PRS14190AsrataMaryam.xml
@@ -1,0 +1,60 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14190AsrataMaryam" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾAsrāta Māryām</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">አስራተ፡ ማርያም፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAsrāta Māryām</persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14190AsrataMaryam" passive="Tanasee1"/>
+                    <relation name="saws:hasParent" active="PRS14190AsrataMaryam" passive="PRS14191AmdaMikael"/>
+                    <relation name="saws:hasParent" active="PRS14190AsrataMaryam" passive="PRS14192BetaMaryam"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14190AsrataMaryam.xml
+++ b/new/PRS14190AsrataMaryam.xml
@@ -51,8 +51,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14190AsrataMaryam" passive="Tanasee1"/>
-                    <relation name="saws:hasParent" active="PRS14190AsrataMaryam" passive="PRS14191AmdaMikael"/>
-                    <relation name="saws:hasParent" active="PRS14190AsrataMaryam" passive="PRS14192BetaMaryam"/>
+                    <relation name="snap:SonOf" active="PRS14190AsrataMaryam" passive="PRS14191AmdaMikael"/>
+                    <relation name="snap:SonOf" active="PRS14190AsrataMaryam" passive="PRS14192BetaMaryam"/>
                 </listRelation>
             </listPerson><!---->
         </body>

--- a/new/PRS14191AmdaMikael.xml
+++ b/new/PRS14191AmdaMikael.xml
@@ -44,14 +44,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listPerson>
-                <person>
+                <person sex="1">
                     <persName xml:lang="gez" xml:id="n1">አምደ፡ ሚካኤል፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAmda Mikāʾel</persName>
                     <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14191AmdaMikael" passive="Tanasee1"/>
-                    <relation name="saws:hasChild" active="PRS14191AmdaMikael" passive="PRS14190AsrataMaryam"/>
+                    <relation name="snap:FatherOf" active="PRS14191AmdaMikael" passive="PRS14190AsrataMaryam"/>
                 </listRelation>
             </listPerson><!---->
         </body>

--- a/new/PRS14191AmdaMikael.xml
+++ b/new/PRS14191AmdaMikael.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14191AmdaMikael" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾAmda Mikāʾel</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person>
+                    <persName xml:lang="gez" xml:id="n1">አምደ፡ ሚካኤል፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAmda Mikāʾel</persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14191AmdaMikael" passive="Tanasee1"/>
+                    <relation name="saws:hasChild" active="PRS14191AmdaMikael" passive="PRS14190AsrataMaryam"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14192BetaMaryam.xml
+++ b/new/PRS14192BetaMaryam.xml
@@ -44,14 +44,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listPerson>
-                <person>
+                <person sex="2">
                     <persName xml:lang="gez" xml:id="n1">ቤተ፡ ማርያም፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Beta Māryām</persName>
                     <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14192BetaMaryam" passive="Tanasee1"/>
-                    <relation name="saws:hasChild" active="PRS14192BetaMaryam" passive="PRS14190AsrataMaryam"/>
+                    <relation name="snap:MotherOf" active="PRS14192BetaMaryam" passive="PRS14190AsrataMaryam"/>
                 </listRelation>
             </listPerson><!---->
         </body>

--- a/new/PRS14192BetaMaryam.xml
+++ b/new/PRS14192BetaMaryam.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14192BetaMaryam" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Beta Māryām</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person>
+                    <persName xml:lang="gez" xml:id="n1">ቤተ፡ ማርያም፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Beta Māryām</persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14192BetaMaryam" passive="Tanasee1"/>
+                    <relation name="saws:hasChild" active="PRS14192BetaMaryam" passive="PRS14190AsrataMaryam"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14193TasfaMaryam.xml
+++ b/new/PRS14193TasfaMaryam.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14193TasfaMaryam" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Tasfā Māryām</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ተስፋ፡ ማርያም፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Tasfā Māryām</persName>
+                    <occupation type="ecclesiastic">nəbura ʾəd</occupation>
+                    <birth/>
+                    <death/>
+                    <floruit/>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14193TasfaMaryam" passive="Tanasee1"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created new records for persons testified in Tanasee1 on f. 24ra-b. According to my judgement based on palaeography and position in the codex, this addition can be dated to the 16th until the 18th century. I would be happy, if you had also a look on the account to support the palaeographic dating:

<img width="478" alt="Screenshot 2023_Asrata Maryam (1)" src="https://github.com/BetaMasaheft/Persons/assets/40291787/809f6854-5e10-403a-9fa7-4fc522bd0e87">
<img width="447" alt="Screenshot 2023_Asrata Maryam (2)" src="https://github.com/BetaMasaheft/Persons/assets/40291787/71c43a78-5181-474a-89dc-e97aea48a6be">


