### PR TITLE
PRS in Tanasee1 (no.15)

### DIFF
--- a/new/PRS14194Atnatewos.xml
+++ b/new/PRS14194Atnatewos.xml
@@ -47,7 +47,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <person sex="1">
                     <persName xml:lang="gez" xml:id="n1">አትናቴዎስ</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAtnātewos</persName>
-                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                    <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14194Atnatewos" passive="Tanasee1"/>

--- a/new/PRS14194Atnatewos.xml
+++ b/new/PRS14194Atnatewos.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="1">
-                    <persName xml:lang="gez" xml:id="n1">አትናቴዎስ</persName>
+                    <persName xml:lang="gez" xml:id="n1">አትናቴዎስ፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAtnātewos</persName>
                     <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>
                 </person>

--- a/new/PRS14194Atnatewos.xml
+++ b/new/PRS14194Atnatewos.xml
@@ -1,0 +1,58 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14194Atnatewos" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾAtnātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">አትናቴዎስ</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAtnātewos</persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14194Atnatewos" passive="Tanasee1"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14195TaklaMaryam.xml
+++ b/new/PRS14195TaklaMaryam.xml
@@ -1,0 +1,68 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14195TaklaMaryam" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Takla Māryām</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ተክለ፡ ማርያም፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Takla Māryām</persName>
+                    <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14195TaklaMaryam" passive="Tanasee1"/>
+                    <relation name="dc:relation" active="PRS14195TaklaMaryam" passive="PRS14068TaklaMaryam"><desc>Possibly
+                        the same person as <ref target="#PRS14068TaklaMaryam"/>, who is witnessed in another addition in 
+                        <ref target="#Tanasee1"/>.</desc></relation>
+                    <relation name="dc:relation" active="PRS14195TaklaMaryam" passive="PRS14160TaklaMaryam"><desc>Possibly
+                        the same person as <ref target="#PRS14160TaklaMaryam"/>, who is witnessed in another addition in 
+                        <ref target="#Tanasee1"/>.</desc></relation>
+                    <relation name="dc:relation" active="PRS14195TaklaMaryam" passive="PRS14096TaklaMaryam"><desc>Possibly
+                        the same person as <ref target="#PRS14096TaklaMaryam"/>, who is witnessed in another addition in 
+                        <ref target="#Tanasee1"/>.</desc></relation>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14195TaklaMaryam.xml
+++ b/new/PRS14195TaklaMaryam.xml
@@ -48,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" xml:id="n1">ተክለ፡ ማርያም፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Takla Māryām</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
-                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                    <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14195TaklaMaryam" passive="Tanasee1"/>

--- a/new/PRS14196Diyosqoros.xml
+++ b/new/PRS14196Diyosqoros.xml
@@ -48,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" xml:id="n1">ዲዮስቆሮስ</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Diyosqoros</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
-                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                    <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14196Diyosqoros" passive="Tanasee1"/>

--- a/new/PRS14196Diyosqoros.xml
+++ b/new/PRS14196Diyosqoros.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14196Diyosqoros" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Diyosqoros</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ዲዮስቆሮስ</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Diyosqoros</persName>
+                    <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14196Diyosqoros" passive="Tanasee1"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14196Diyosqoros.xml
+++ b/new/PRS14196Diyosqoros.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="1">
-                    <persName xml:lang="gez" xml:id="n1">ዲዮስቆሮስ</persName>
+                    <persName xml:lang="gez" xml:id="n1">ዲዮስቆሮስ፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Diyosqoros</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
                     <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>

--- a/new/PRS14197Zamalakot.xml
+++ b/new/PRS14197Zamalakot.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="1">
-                    <persName xml:lang="gez" xml:id="n1">ዘመለኮት</persName>
+                    <persName xml:lang="gez" xml:id="n1">ዘመለኮት፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Zamalakot</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
                     <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>

--- a/new/PRS14197Zamalakot.xml
+++ b/new/PRS14197Zamalakot.xml
@@ -48,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" xml:id="n1">ዘመለኮት</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Zamalakot</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
-                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                    <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14197Zamalakot" passive="Tanasee1"/>

--- a/new/PRS14197Zamalakot.xml
+++ b/new/PRS14197Zamalakot.xml
@@ -1,0 +1,65 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14197Zamalakot" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Zamalakot</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ዘመለኮት</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Zamalakot</persName>
+                    <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14197Zamalakot" passive="Tanasee1"/>
+                    <relation name="dc:relation" active="PRS14197Zamalakot" passive="PRS13297Zamalakot"><desc>Possibly
+                        the same person as <ref target="#PRS13297Zamalakot"/>.</desc></relation>
+                    <relation name="dc:relation" active="PRS14197Zamalakot" passive="PRS13793Zamalakot"><desc>Possibly
+                        the same person as <ref target="#PRS13793Zamalakot"/>.</desc></relation>
+                    <relation name="dc:relation" active="PRS14197Zamalakot" passive="PRS11879Zamalakot"><desc>Possibly
+                        the same person as <ref target="#PRS11879Zamalakot"/>.</desc></relation>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14198Tewodros.xml
+++ b/new/PRS14198Tewodros.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14198Tewodros" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Tewodros</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ቴዎድሮስ</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Tewodros</persName>
+                    <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14198Tewodros" passive="Tanasee1"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14198Tewodros.xml
+++ b/new/PRS14198Tewodros.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="1">
-                    <persName xml:lang="gez" xml:id="n1">ቴዎድሮስ</persName>
+                    <persName xml:lang="gez" xml:id="n1">ቴዎድሮስ፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Tewodros</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
                     <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>

--- a/new/PRS14198Tewodros.xml
+++ b/new/PRS14198Tewodros.xml
@@ -48,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" xml:id="n1">ቴዎድሮስ</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Tewodros</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
-                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                    <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14198Tewodros" passive="Tanasee1"/>

--- a/new/PRS14199Abadir.xml
+++ b/new/PRS14199Abadir.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14199Abadir" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾAbadir</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">አበዲር</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAbadir</persName>
+                    <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
+                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14199Abadir" passive="Tanasee1"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14199Abadir.xml
+++ b/new/PRS14199Abadir.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="1">
-                    <persName xml:lang="gez" xml:id="n1">አበዲር</persName>
+                    <persName xml:lang="gez" xml:id="n1">አበዲር፡</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAbadir</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
                     <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>

--- a/new/PRS14199Abadir.xml
+++ b/new/PRS14199Abadir.xml
@@ -48,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" xml:id="n1">አበዲር</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAbadir</persName>
                     <persName xml:lang="gez" type="normalized"><roleName type="title">ʾabbā</roleName></persName>
-                    <floruit notBefore="1500" notAfter="1800">16th to 18th century</floruit>
+                    <floruit notBefore="1600" notAfter="1750">17th to first half of 18th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14199Abadir" passive="Tanasee1"/>


### PR DESCRIPTION
I found more personal names in another addition. The height of the characters is rather small and for this reason some are barely legible. This is especially true for the glosses, that are written next to this addition.

<img width="544" alt="Screenshot 2023_Atnatewos (1)" src="https://github.com/BetaMasaheft/Persons/assets/40291787/716121e6-c211-40d0-be3a-0e5c9dc0f8da">
<img width="516" alt="Screenshot 2023_Atnatewos (2)" src="https://github.com/BetaMasaheft/Persons/assets/40291787/ff9fa5c9-be11-41dc-89b1-97a079d56302">
