### PR TITLE
Create PRS14209Daneel in Tanasee1 (no. 19)

### DIFF
--- a/new/PRS14209Daneel.xml
+++ b/new/PRS14209Daneel.xml
@@ -1,0 +1,60 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14209Daneel" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Dānəʾel</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-21">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ዳንኤል</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Dānəʾel</persName>
+                    <persName xml:lang="gez" type="normalized">ʾabbā</persName>
+                    <persName xml:lang="gez" type="normalized">ʾabba makān</persName>
+                    <floruit notBefore="1300" notAfter="1400">14th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14209Daneel" passive="Tanasee1"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14209Daneel.xml
+++ b/new/PRS14209Daneel.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Dānəʾel</title>
+                <title>Dānǝʾel</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <listPerson>
                 <person sex="1">
                     <persName xml:lang="gez" xml:id="n1">ዳንኤል</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1">Dānəʾel</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Dānǝʾel</persName>
                     <persName xml:lang="gez" type="normalized">ʾabbā</persName>
                     <persName xml:lang="gez" type="normalized">ʾabba makān</persName>
                     <floruit notBefore="1300" notAfter="1400">14th century</floruit>


### PR DESCRIPTION
I found a person with the name Dānəʾəl in an addition in Tanasee1 on folio 234r. 

He bears the title ʾabbā and the title ʾabbāmakān. 

He shall be contemporary of PRS8595SayfaAr and PRS8387SalamaI. Even though PRS3429DawitII is mentioned shortly after, this mention is in another context.

However, I think the note is much older because of the palaeography and the position on two folia, that I think belong to different quires, that have been joined in later time.

<img width="700" alt="Screenshot 2023_abbamakana abba Daneel" src="https://github.com/BetaMasaheft/Persons/assets/40291787/a92e7225-9984-42d8-a3f6-8205c5419188">
