### PR TITLE
Update and create PRS IDs in Tanasee1 (no. 20)

### DIFF
--- a/new/PRS14210Tomas.xml
+++ b/new/PRS14210Tomas.xml
@@ -1,11 +1,11 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14086Qalementos" xml:lang="en" type="pers">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14210Tomas" xml:lang="en" type="pers">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Qalemənṭos</title>
+                <title>Tomās</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -38,19 +38,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2023-09-29">Created entity</change>
+            <change who="CH" when="2023-11-21">Created entity</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
             <listPerson>
-                <person>
-                    <persName xml:lang="gez" xml:id="n1">ቀሌምንጦስ</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1">Qalemənṭos</persName>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ቶማስ</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Tomās</persName>
+                    <occupation type="ecclesiastic">qes gabaz</occupation>
                     <floruit notBefore="1350" notAfter="1450">Second half of 14th or first half of 15th century</floruit>
                 </person>
                 <listRelation>
-                    <relation name="lawd:hasAttestation" active="PRS14086Qalementos" passive="Tanasee1"/>
+                    <relation name="lawd:hasAttestation" active="PRS14210Tomas" passive="Tanasee1"/>
+                    <relation name="dc:relation" active="PRS14210Tomas" passive="PRS14203Tomas"><desc>Possibly the same person
+                        as <ref target="PRS14203Tomas"/>, who is mentioned in another addition in the same manuscript 
+                        <ref target="#Tanasee1"/></desc></relation>
                 </listRelation>
             </listPerson><!---->
         </body>

--- a/new/PRS14211Yaeqob.xml
+++ b/new/PRS14211Yaeqob.xml
@@ -1,11 +1,11 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14086Qalementos" xml:lang="en" type="pers">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14211Yaeqob" xml:lang="en" type="pers">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Qalemənṭos</title>
+                <title>Yāʿəqob</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -38,19 +38,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2023-09-29">Created entity</change>
+            <change who="CH" when="2023-11-21">Created entity</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
             <listPerson>
-                <person>
-                    <persName xml:lang="gez" xml:id="n1">ቀሌምንጦስ</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1">Qalemənṭos</persName>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ያዕቆብ</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Yāʿəqob</persName>
+                    <occupation type="ecclesiastic">raqʷ māsarā</occupation>
                     <floruit notBefore="1350" notAfter="1450">Second half of 14th or first half of 15th century</floruit>
                 </person>
                 <listRelation>
-                    <relation name="lawd:hasAttestation" active="PRS14086Qalementos" passive="Tanasee1"/>
+                    <relation name="lawd:hasAttestation" active="PRS14211Yaeqob" passive="Tanasee1"/>
                 </listRelation>
             </listPerson><!---->
         </body>


### PR DESCRIPTION
I found two new PRS IDs in Tanasee1 on folio 234va. 

I dated the floruits of these two persons and the already existing PRS14086Qalementos very early to the second half of the 14th or the first half of the 15th century because of the name of king ዳዊት mentioned above. I am puzzled as to which king might be mentioned here and have decided on David I as the earliest possible, but others are also possible. 

How should I proceed if the dating is not certain? Should I leave ዳዊት unrecorded and delete the floruit? Or can this addition be dated by deducing the palaeographic forms?

<img width="315" alt="Screenshot 2023-Tomas" src="https://github.com/BetaMasaheft/Persons/assets/40291787/eee62ca5-381c-45a9-b96c-5135017f8e3d">
<img width="365" alt="Screenshot 2023_Tomas (2)" src="https://github.com/BetaMasaheft/Persons/assets/40291787/3dc3dba6-36c6-48f6-9e59-afec2c5d966c">
