### PR TITLE
PRS in leporello from Luzern

### DIFF
--- a/new/PRS14224SilviaFrei.xml
+++ b/new/PRS14224SilviaFrei.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="2">
-                    <persName xml:lang="de" xml:id="n1">Silvia Frei</persName>
+                    <persName><forename>Silvia</forename><surname>Frei</surname></persName>
                     <birth>1927</birth>
                 </person>
                 <listRelation>

--- a/new/PRS14224SilviaFrei.xml
+++ b/new/PRS14224SilviaFrei.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="2">
-                    <persName><forename>Silvia</forename><surname>Frei</surname></persName>
+                    <persName><forename>Silvia</forename> <surname>Frei</surname></persName>
                     <birth>1927</birth>
                 </person>
                 <listRelation>

--- a/new/PRS14224SilviaFrei.xml
+++ b/new/PRS14224SilviaFrei.xml
@@ -1,0 +1,58 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14224SilviaFrei" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Silvia Frei</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="de">German</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-28">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="2">
+                    <persName xml:lang="de" xml:id="n1">Silvia Frei</persName>
+                    <birth>1927</birth>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14224SilviaFrei" passive="MsEth1"/>
+                    <relation name="betmas:wifeOf" active="PRS14224SilviaFrei" passive="PRS14225WalterFrei"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14225WalterFrei.xml
+++ b/new/PRS14225WalterFrei.xml
@@ -44,9 +44,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listPerson>
-                <person sex="1">
-                    <persName xml:lang="de" xml:id="n1">Walter Frei</persName>
-                    <occupation type="academic">Professor for History of the Church and dogmas at the university of Bern</occupation>
+                <person sex="1" sameAs="wd:Q95326507">
+                    <persName><forename>Walter</forename><surname>Frei</surname></persName>
+                    <occupation type="academic">Professor for History of the Church and dogmas at the university of 
+                        <placeName ref="LOC1868Bern"/></occupation>
                     <faith type="Catholicism"/>
                     <birth>1927-03-17</birth>
                     <death>2022-04-02</death>

--- a/new/PRS14225WalterFrei.xml
+++ b/new/PRS14225WalterFrei.xml
@@ -49,8 +49,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <occupation type="academic">Professor for History of the Church and dogmas at the university of 
                         <placeName ref="LOC1868Bern"/></occupation>
                     <faith type="Catholicism"/>
-                    <birth>1927-03-17</birth>
-                    <death>2022-04-02</death>
+                    <birth when="1927-03-17">17 March 1927</birth>
+                    <death when="2022-04-02">2 April 2022</death>
                 </person>
                 <listRelation>
                     <relation name="betmas:husbandOf" active="PRS14225WalterFrei" passive="PRS14224SilviaFrei"/>

--- a/new/PRS14225WalterFrei.xml
+++ b/new/PRS14225WalterFrei.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14225WalterFrei" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Walter Frei</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-28">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="de" xml:id="n1">Walter Frei</persName>
+                    <occupation type="academic">Professor for History of the Church and dogmas at the university of Bern</occupation>
+                    <faith type="Catholicism"/>
+                    <birth>1927-03-17</birth>
+                    <death>2022-04-02</death>
+                </person>
+                <listRelation>
+                    <relation name="betmas:husbandOf" active="PRS14225WalterFrei" passive="PRS14224SilviaFrei"/>
+                    <relation name="lawd:hasAttestation" active="PRS14225WalterFrei" passive="MsEth1"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14225WalterFrei.xml
+++ b/new/PRS14225WalterFrei.xml
@@ -45,7 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="1" sameAs="wd:Q95326507">
-                    <persName><forename>Walter</forename><surname>Frei</surname></persName>
+                    <persName><forename>Walter</forename> <surname>Frei</surname></persName>
                     <occupation type="academic">Professor for History of the Church and dogmas at the university of 
                         <placeName ref="LOC1868Bern"/></occupation>
                     <faith type="Catholicism"/>

--- a/new/PRS14226WaldaIyasus.xml
+++ b/new/PRS14226WaldaIyasus.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Walda ʾIyāsus Kabbada</title>
+                <title>Walda ʾIyāsus Kabbada Yərsāw</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -45,8 +45,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="1">
-                    <persName xml:lang="gez" xml:id="n1">ወልደ፡ ኢያሱስ፡ ከበደ፡</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walda ʾIyāsus Kabbada</persName>
+                    <persName xml:lang="gez" xml:id="n1">ወልደ፡ ኢያሱስ፡ ከበደ፡ ይርሳው</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walda ʾIyāsus Kabbada Yərsāw</persName>
                     <floruit notBefore="1650" notAfter="1950">Second half of 17th to first half of the 20th century</floruit>
                 </person>
                 <listRelation>

--- a/new/PRS14226WaldaIyasus.xml
+++ b/new/PRS14226WaldaIyasus.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Walda ʾIyāsus Kabbada Yərsāw</title>
+                <title>Walda ʾIyāsus Kabbada Yǝrsāw</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <listPerson>
                 <person sex="1">
                     <persName xml:lang="gez" xml:id="n1">ወልደ፡ ኢያሱስ፡ ከበደ፡ ይርሳው</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walda ʾIyāsus Kabbada Yərsāw</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walda ʾIyāsus Kabbada Yǝrsāw</persName>
                     <floruit notBefore="1650" notAfter="1950">Second half of 17th to first half of the 20th century</floruit>
                 </person>
                 <listRelation>

--- a/new/PRS14226WaldaIyasus.xml
+++ b/new/PRS14226WaldaIyasus.xml
@@ -1,0 +1,58 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14226WaldaIyasus" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Walda ʾIyāsus Kabbada</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-28">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ወልደ፡ ኢያሱስ፡ ከበደ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walda ʾIyāsus Kabbada</persName>
+                    <floruit notBefore="1650" notAfter="1950">Second half of 17th to first half of the 20th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14226WaldaIyasus" passive="MsEth1"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14226WaldaIyasus.xml
+++ b/new/PRS14226WaldaIyasus.xml
@@ -47,7 +47,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <person sex="1">
                     <persName xml:lang="gez" xml:id="n1">ወልደ፡ ኢያሱስ፡ ከበደ፡ ይርሳው</persName>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Walda ʾIyāsus Kabbada Yǝrsāw</persName>
-                    <floruit notBefore="1650" notAfter="1950">Second half of 17th to first half of the 20th century</floruit>
+                    <floruit notBefore="1850" notAfter="1950">Second half of 19th to first half of the 20th century</floruit>
                 </person>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="PRS14226WaldaIyasus" passive="MsEth1"/>


### PR DESCRIPTION
I have created three PRS IDs for persons in the Leporello from Lucerne, which has the preliminary shelfmark MsEth1.

Silvia and Walter Frei can be found on various websites that show the dates of birth and death for Walter Frei.

For PRS14226WaldaIyasus, I cannot say whether his name is just Walda ʾIyāsus or whether the name also includes the following one or two words (ከበደ፡ ይርሳው). I added Kabbada to the name because it is familiar to me. I do not know if yərsāw is also a name or an epithet or a phrase.

he floruit of this person depends on the palaeographic analysis. The library estimated the 19th century, which may be true. However, I think that the manuscript, and therefore the person, may be much older, dating from the second half of the 17th century or even the 18th century (also discussed in issue [#2401](https://github.com/BetaMasaheft/Documentation/issues/2401)).

<img width="579" alt="Screenshot 2023_Walda Iyasus Kabbada" src="https://github.com/BetaMasaheft/Persons/assets/40291787/0fe4980a-b825-41de-bcc6-86ef5d2d51f9">
