### PR TITLE
Create PRS14230GBRaimondi

### DIFF
--- a/new/PRS14230GBRaimondi.xml
+++ b/new/PRS14230GBRaimondi.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14230GBRaimondi" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Giovanni Battista Raimondi</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-12-18">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName>
+                        <forename>Giovanni</forename>
+                        <forename>Battista</forename>
+                        <surname>Raimondi</surname>
+                    </persName>
+                    <occupation type="academic">Scientific director of the Typographia Medicea in Rome</occupation>
+                    <nationality type="Italy"/>
+                    <birth cert="medium" when="1536">1536</birth>
+                    <death cert="high" when="1614">1614</death>
+                </person>
+                <listRelation>
+                    <relation name="saws:isAttributedToAuthor" active="PRS14230GBRaimondi" passive="BMLor321"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14230GBRaimondi.xml
+++ b/new/PRS14230GBRaimondi.xml
@@ -44,13 +44,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listPerson>
-                <person sex="1">
-                    <persName>
+                <person sex="1" sameAs="Q3105122">
+                    <persName xml:id="n1">
                         <forename>Giovanni</forename>
                         <forename>Battista</forename>
                         <surname>Raimondi</surname>
                     </persName>
-                    <occupation type="academic">Scientific director of the Typographia Medicea in Rome</occupation>
+                    <persName xml:id="n2">
+                        <forename>Giambattista</forename>
+                    </persName>
+                    <occupation type="academic">Scientific director of the Typographia Medicea in <placeName ref="LOC5374Rome"/>.</occupation>
                     <nationality type="Italy"/>
                     <birth cert="medium" when="1536">1536</birth>
                     <death cert="high" when="1614">1614</death>
@@ -59,6 +62,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="saws:isAttributedToAuthor" active="PRS14230GBRaimondi" passive="BMLor321"/>
                 </listRelation>
             </listPerson><!---->
+            <listBibl type="secondary">
+                <bibl> 
+                    <ptr target="bm:Farina2018RaimondisTravel"/>
+                </bibl>
+            </listBibl>
         </body>
     </text>
 </TEI>

--- a/new/PRS14230GBRaimondi.xml
+++ b/new/PRS14230GBRaimondi.xml
@@ -59,7 +59,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <death cert="high" when="1614">1614</death>
                 </person>
                 <listRelation>
-                    <relation name="saws:isAttributedToAuthor" active="PRS14230GBRaimondi" passive="BMLor321"/>
+                    <relation name="saws:isCopierOf" active="PRS14230GBRaimondi" passive="BMLor321"/>
                 </listRelation>
             </listPerson><!---->
             <listBibl type="secondary">


### PR DESCRIPTION
I created an ID for Giovanni Battista Raimondi. He claimed by Assemani to be the author of the lexicon in BMLor321. The endeavours of this person is described in bm:Farina2018RaimondisTravel, however I think it is not our policy to refer to secondary literature in PRS records, correct?