### PR TITLE
PRS in EMML1832 (no.7)

### DIFF
--- a/new/PRS14277Mamas.xml
+++ b/new/PRS14277Mamas.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14277Mamas" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Māmās</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ማማስ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Māmās</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14277Mamas" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14277Mamas.xml
+++ b/new/PRS14277Mamas.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Māmās</persName>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>

--- a/new/PRS14278AmlakMoa.xml
+++ b/new/PRS14278AmlakMoa.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAmlāk Moʾa</persName>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>

--- a/new/PRS14278AmlakMoa.xml
+++ b/new/PRS14278AmlakMoa.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14278AmlakMoa" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾAmlāk Moʾa</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">አምላክ፡ ምአ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAmlāk Moʾa</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="dc:relation" active="PRS14278AmlakMoa" passive="PRS14246AmlakMoa"><desc>Possibly the same person
+                        as <persName ref="PRS14246AmlakMoa"/>, who is mentioned in another addition in the same manuscript 
+                        <ref type="mss" corresp="EMML1832"/>.</desc></relation>
+                    <relation name="lawd:hasAttestation" active="PRS14278AmlakMoa" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14279AmlakaBena.xml
+++ b/new/PRS14279AmlakaBena.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14279AmlakaBena" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾAmlāka Bǝna</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">አምላከ፡ ብነ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAmlāka Bǝna</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14279AmlakaBena" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14279AmlakaBena.xml
+++ b/new/PRS14279AmlakaBena.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾAmlāka Bǝna</persName>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>

--- a/new/PRS14280Simeon.xml
+++ b/new/PRS14280Simeon.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Sǝmʿon</persName>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>

--- a/new/PRS14280Simeon.xml
+++ b/new/PRS14280Simeon.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14280Simeon" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Sǝmʿon</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ስምዖን፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Sǝmʿon</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14280Simeon" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14281Senoda.xml
+++ b/new/PRS14281Senoda.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Senodā</persName>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>

--- a/new/PRS14281Senoda.xml
+++ b/new/PRS14281Senoda.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14281Senoda" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Senodā</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ሴኖዳ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Senodā</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14281Senoda" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14282YohannesKama.xml
+++ b/new/PRS14282YohannesKama.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14282YohannesKama" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Yoḥannǝs Kamā</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ዮሐንስ፡ ከማ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Yoḥannǝs Kamā</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14282YohannesKama" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14282YohannesKama.xml
+++ b/new/PRS14282YohannesKama.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Yoḥannǝs Kamā</persName>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>

--- a/new/PRS14283YeheyyesTaameno.xml
+++ b/new/PRS14283YeheyyesTaameno.xml
@@ -1,0 +1,62 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14283YeheyyesTaameno" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Yǝheyyǝs Taʾammǝno</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ይሄይስ፡ ተአምኖ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Yǝheyyǝs Taʾammǝno</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14283YeheyyesTaameno" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14283YeheyyesTaameno.xml
+++ b/new/PRS14283YeheyyesTaameno.xml
@@ -50,7 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>

--- a/new/PRS14284Endreyas.xml
+++ b/new/PRS14284Endreyas.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">ʾƎndrǝyās</persName>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>

--- a/new/PRS14284Endreyas.xml
+++ b/new/PRS14284Endreyas.xml
@@ -1,0 +1,63 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14284Endreyas" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>ʾƎndrǝyās</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">እንድርያስ፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">ʾƎndrǝyās</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="dc:relation" active="PRS14284Endreyas" passive="PRS3800endreyas"><desc>Possibly the same person as
+                        <persName ref="PRS3800endreyas"/>, who became abbot of <placeName ref="LOC2237DabraA"/> shortly afterwards.</desc></relation>
+                    <relation name="lawd:hasAttestation" active="PRS14284Endreyas" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14285ZaraBuruk.xml
+++ b/new/PRS14285ZaraBuruk.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14285ZaraBuruk" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Zarʾa Buruk</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-01-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ዘርአ፡ ቡሩክ፡ </persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Zarʾa Buruk</persName>
+                    <faith type="EOTC"/>
+                    <occupation type="ecclesiastic">diyāqon</occupation>
+                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14285ZaraBuruk" passive="EMML1832"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14285ZaraBuruk.xml
+++ b/new/PRS14285ZaraBuruk.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <persName xml:lang="gez" type="normalized" corresp="#n1">Zarʾa Buruk</persName>
                     <faith type="EOTC"/>
                     <occupation type="ecclesiastic">diyāqon</occupation>
-                    <floruit notBefore="1320" notAfter="1400">14th</floruit>
+                    <floruit notBefore="1320" notAfter="1400">14th century</floruit>
                     <residence><placeName ref="INS0327DHE">Dabra Ḥayq ʾƎsṭifānos</placeName></residence>
                 </person>
                 <listRelation>


### PR DESCRIPTION
I have encoded personal names EMML1832 - namely 9 out of 12 names that we were able to identify as deacons in a note on incense from the 14th century, as discussed in https://github.com/BetaMasaheft/Documentation/issues/2458. 

However, there are three more entities in this list that should result in 12 people, which I have postponed because they are not without problems for me: 

1) ሐደራ -> the same name also appears in the list of countries immediately above. I do not know if this is a coincidence or if it is the same personal name in both cases. 
2) ዘበልዐ፡ ምድረ፡ <persName ref="PRS00000000000000">ልደታ፡ ለማርያም። is accompanied by the formula za-balʿa mǝdra which puzzled us so much.
 3) ዘበልዐ፡ ምድረ፡ <persName ref="PRS00000000000">መርቆርዮስ። The same formula again, and even the same name, which I have coded as PRS14268Marqoryos, but I happen not to be sincere as to whether it really is a personal name. If we do not find a flawless solution, I suggest we refrain from doing so and leave these three names without markup.

<img width="562" alt="Screenshot 2024_incense" src="https://github.com/BetaMasaheft/Persons/assets/40291787/f4f1fccc-aa4f-43db-b173-59416d9b3dc2">
