### PR TITLE
PRS in BLorient8818

### DIFF
--- a/new/PRS14438Lieder.xml
+++ b/new/PRS14438Lieder.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14438Lieder" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>J. R. T. Lieder</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Read by <persName ref="PRS8999Strelcyn"/> in <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/>
+                    <citedRange unit="page">79</citedRange></bibl> as 'B. R. T. Lieder', but according to Stephen Emmel in
+                    <bibl><ptr target="bm:Emmel2023Curzon"/><citedRange unit="page">269</citedRange></bibl> this reading is a
+                    misreading for 'J. R. T. Lieder', who is known as a reverend and traveler to Egypt and husband of 
+                    <persName ref="PRS14439AliceLieder">Alice Lieder</persName>.</p>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-05-27">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName><forename>J.</forename> <forename>R.</forename> <forename>T.</forename> 
+                        <surname>Lieder</surname></persName>
+                    <faith type="Protestantism"/>
+                    <occupation type="ecclesiastic">reverend</occupation>
+                    <floruit notBefore="1800" notAfter="1900">19th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="betmas:husbandOf" active="PRS14438Lieder" passive="PRS14439AliceLieder"/>
+                    <relation name="saws:hasOwned" active="PRS14438Lieder" passive="BLorient8818"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14439AliceLieder.xml
+++ b/new/PRS14439AliceLieder.xml
@@ -1,0 +1,57 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14439AliceLieder" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Alice Lieder</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-05-27">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="2">
+                    <persName xml:lang="gez" xml:id="n1"><forename>Alice</forename> <surname>Lieder</surname></persName> 
+                    <occupation type="academic">Author of several archaeological accounts of ancient temples in Egypt.</occupation>
+                    <floruit notBefore="1800" notAfter="1900">19th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="betmas:wifeOf" active="PRS14439AliceLieder" passive="PRS14438Lieder"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14440GabraMasqal.xml
+++ b/new/PRS14440GabraMasqal.xml
@@ -1,0 +1,58 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14440GabraMasqal" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Gabra Masqal</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-05-27">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1">
+                    <persName xml:lang="gez" xml:id="n1">ገብረ፡ መስቀል፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Gabra Masqal</persName>
+                    <floruit notBefore="1800" notAfter="1842">First half of 19th century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="saws:hasOwned" active="PRS14440GabraMasqal" passive="BLorient8818"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created PRS IDs for owners of BLorient8818. The name of Mr. Lieder is present in a letter attached to the manuscript as accompanying material. Stephen Emmel explained in his contribution, that B. R. T. is a misreading for J. R. T. (Lieder). I took the opinion of Emmel and marked the dispute in an abstract. I identified J. R. T. Lieder as a reverend and husband of Egyptologist Alice Lieder and created also a record for her.