### PR TITLE
Create PRS in BLorient11718A

### DIFF
--- a/PRS5001-6000/PRS5226haylase.xml
+++ b/PRS5001-6000/PRS5226haylase.xml
@@ -40,6 +40,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                                   google spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: person</change>
          <change when="2020-03-11" who="DE">Corrected encoding and transliteration.</change>
+         <change when="2024-05-28" who="CH">Updated names and floruit, birth, death and relations</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -48,11 +49,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <person sex="1" sameAs="wd:Q41178">
                 <persName xml:lang="gez" xml:id="n1" type="regnal">ኃይለ፡ ሥላሴ፡</persName>
                <persName xml:lang="gez" type="normalized" corresp="#n1">Ḫāyla Śǝllāse I</persName>
-              <!-- <persName xml:lang="gez" xml:id="n2"><roleName type="title">ራስ</roleName> ተፈሪ፡ መኰንን፡</persName>
+              <persName xml:lang="gez" xml:id="n2"><roleName type="title">ራስ፡</roleName> ተፈሪ፡ መኰንን፡</persName>
                <persName xml:lang="gez" corresp="#n2" type="normalized"><roleName type="title">rās</roleName> Tafari Makʷannǝn</persName>
-          -->
                <occupation type="ruler">Emperor</occupation>
+               <birth when="1892-07-23">23 July 1892</birth>
+               <death when="1975-08-27">27 August 1975</death>
+               <floruit notBefore="1916" notAfter="1974">He rose to power as Regent of Ethiopia from 27 September 1916 until 2 April 1930 for
+                  Empress <persName ref="PRS10671Zawditu"/> and followed her as Emperor of Ethiopia from 2 April 1930 to 12 September 1974;
+                  He was overthrown in a military coup by the Marxist Derg. He was assassinated by Derg military officers on 27 August 1975.</floruit>
             </person>
+            <listRelation>
+               <relation name="betmas:isSuccessorOf" active="PRS5226haylase" passive="PRS10671Zawditu"/>
+               <relation name="betmas:husbandOf" active="PRS5226haylase" passive="PRS6642MananAs"/>
+               <relation name="snap:FatherOf" active="PRS5226haylase" passive="PRS2112AsfaWas"/>
+               <relation name="snap:FatherOf" active="PRS5226haylase" passive="PRS8337Sahayha"/>
+            </listRelation>
          </listPerson>
       </body>
    </text>

--- a/new/PRS14445BishopGwynne.xml
+++ b/new/PRS14445BishopGwynne.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14445BishopGwynne" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Llewellyn Gwynne</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-05-28">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1" sameAs="wd:Q6662059">
+                    <persName><forename>Llewellyn</forename> <forename>Henry</forename> <surname>Gwynne</surname></persName>
+                    <faith type="Anglican"/>
+                    <occupation type="ecclesiastic">He was the first Anglican Bishop of Egypt and Sudan, serving from 1920 to 1946.</occupation>
+                    <nationality type="UnitedKingdom"/>
+                    <birth>11 June 1863</birth>
+                    <death>9 December 1957</death>
+                    <floruit notBefore="1920" notAfter="1946"/>
+                </person>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="PRS14445BishopGwynne" passive="BLorient11718A"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/PRS14445BishopGwynne.xml
+++ b/new/PRS14445BishopGwynne.xml
@@ -34,6 +34,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <langUsage>
                 <language ident="en">English</language>
+                <language ident="am">Amharic</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
@@ -44,7 +45,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPerson>
                 <person sex="1" sameAs="wd:Q6662059">
-                    <persName><forename>Llewellyn</forename> <forename>Henry</forename> <surname>Gwynne</surname></persName>
+                    <persName xml:lang="en" xml:id="n1"><forename>Llewellyn</forename> <forename>Henry</forename> 
+                        <surname>Gwynne</surname></persName>
+                    <persName xml:lang="am" xml:id="n2">ጉዊን። ኦፍ፡ ከርቱም።</persName>
+                    <persName xml:lang="am" type="normalized" corresp="#n2">Guwin ʾof Kartum</persName>
                     <faith type="Anglican"/>
                     <occupation type="ecclesiastic">He was the first Anglican Bishop of Egypt and Sudan, serving from 1920 to 1946.</occupation>
                     <nationality type="UnitedKingdom"/>

--- a/new/PRS14446Douglas.xml
+++ b/new/PRS14446Douglas.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS14446Douglas" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>John Albert Douglas</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-05-29">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="1" sameAs="wd:Q19661476">
+                    <persName xml:lang="en"><forename>Canon</forename> <forename>John</forename> <forename>Albert</forename>
+                        <surname>Douglas</surname></persName>
+                    <faith type="Anglican"/>
+                    <occupation type="ecclesiastic">He was vicar of St Michael Paternoster Royal from 1933 to 1952. He had served previously, from 
+                        1909 to 1933, at St Luke's Church, Camberwell, in the Diocese of Southwark. </occupation>
+                    <nationality type="UnitedKingdom"/>
+                    <birth when="1868-09-21">21 September 1868</birth>
+                    <death when="1956-07-03">3 July 1956</death>
+                    <floruit notBefore="1909" notAfter="1952">He was a priest of the Church of England and a major figure in Anglican–Orthodox 
+                        relations in the first half of the 20th century from 1909 to 1952.</floruit>
+                </person>
+                <listRelation>
+                    <relation name="saws:hasOwned" active="PRS14446Douglas" passive="BLorient11718A"/>
+                </listRelation>
+            </listPerson><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created PRS IDs for two illustrous figures in Anglican-Orthodox relations, that are attested in BLorient11718A. I also updated the record of ʾAṣ́e Hāyle Śǝllāse, which was lacking information before.