### PR TITLE
Updated ETH records on Gāllā/Oroma, Šānqǝllā, Bāryā and Beta ʾƎsrāʾel

### DIFF
--- a/Ethnic/ETH1219baryas.xml
+++ b/Ethnic/ETH1219baryas.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>barya, soc. group</title>
+            <title>Bāryā (outdated idiom)</title>
             <author/>
          </titleStmt>
          <publicationStmt>
@@ -36,17 +36,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="PL" when="2016-10-18"> Created file from google
                                 spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: ethnic</change>
+         <change when="2024-09-17" who="CH">Updated name and added bibliography.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPerson>
             <personGrp role="ethnic">
-               <persName xml:id="n1">
-                  <orgName>barya, soc. group</orgName>
-               </persName>
+               <persName xml:id="n1" xml:lang="gez"><orgName>ባርያ፡</orgName></persName>
+               <persName corresp="#n1" xml:lang="gez" type="normalized"><orgName>Bāryā (outdated idiom)</orgName></persName>
             </personGrp>
          </listPerson>
+         <listBibl type="secondary">
+            <bibl>
+               <ptr target="bm:Salamon2003Barya"/>
+            </bibl>            
+         </listBibl>
       </body>
    </text>
 </TEI>

--- a/Ethnic/ETH1274Betaes.xml
+++ b/Ethnic/ETH1274Betaes.xml
@@ -37,25 +37,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                                 spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: ethnic</change>
          <change who="SG" when="2018-10-24">additions</change>
+         <change when="2024-09-17" who="CH">Updated name and added bibliography.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPerson>
             <personGrp role="ethnic">
-               <persName xml:id="n1">
+               <persName xml:id="n1" type="main" xml:lang="gez">
                  ቤተ፡ እስራኤል፡
                </persName>
-               <persName corresp="#n1" type="normalized">
+               <persName corresp="#n1" type="normalized" xml:lang="gez">
                   Beta ʾƎsrāʾel
                </persName>
                
                
-               <persName xml:id="n2">
+               <persName xml:id="n2" type="nick" xml:lang="gez">
                   ፈላሻ፡
                </persName>
-               <persName corresp="#n2" type="normalized">
-                  Falāšā
+               <persName corresp="#n2" type="normalized" xml:lang="gez">
+                  Falāšā (outdated idiom)
                </persName>
                
             </personGrp>
@@ -76,11 +77,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <ptr target="bm:Boavida2011PaezII"/>
                <citedRange unit="page">206-259</citedRange>
             </bibl>
-            
-            
-            
-            
-            
+            <bibl> 
+               <ptr target="bm:Kaplan2003BeteEsrael"/>
+            </bibl>
          </listBibl>
       </body>
    </text>

--- a/Ethnic/ETH1508Gallai.xml
+++ b/Ethnic/ETH1508Gallai.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Galla, idiom</title>
+            <title>Galla (outdated idiom)</title>
             <author/>
          </titleStmt>
          <publicationStmt>
@@ -36,17 +36,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="PL" when="2016-10-18"> Created file from google
                                 spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: ethnic</change>
+         <change when="2024-09-17" who="CH">Updated name and added bibliography.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPerson>
             <personGrp role="ethnic">
-               <persName xml:id="n1">
-                  <orgName>Galla, idiom</orgName>
-               </persName>
+               <persName xml:id="n1" xml:lang="am"><orgName>ጋላ፡</orgName></persName>
+               <persName corresp="#n1" xml:lang="am" type="normalized"><orgName>Gāllā (outdated)</orgName></persName>
             </personGrp>
          </listPerson>
+         <listBibl type="secondary">
+            <bibl>
+               <ptr target="bm:Baxter2005Galla"/>
+            </bibl>            
+         </listBibl>
       </body>
    </text>
 </TEI>

--- a/Ethnic/ETH1973Oromo.xml
+++ b/Ethnic/ETH1973Oromo.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Oromo</title>
+            <title>Oromo (people)</title>
             <author/>
          </titleStmt>
          <publicationStmt>
@@ -36,21 +36,30 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="PL" when="2016-10-18"> Created file from google
                                 spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: ethnic</change>
+         <change when="2024-09-17" who="CH">Updated name and added bibliography.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPerson>
             <personGrp role="ethnic">
-               <persName xml:id="n1">
+               <persName xml:id="n1" type="main">
                   <orgName>Oromo</orgName>
                </persName>
-               <persName xml:id="n2">
-                  <orgName>Galla</orgName>
+               <persName xml:id="n2" xml:lang="am" type="nick">
+                  <orgName>ጋላ፡</orgName>
                </persName>
-               
+               <persName corresp="#n2" type="normalized" xml:lang="am">Gāllā (outdated)</persName>
             </personGrp>
          </listPerson>
+         <listBibl type="secondary">
+            <bibl>
+               <ptr target="bm:Hultin2010Oromo"/>
+            </bibl>
+            <bibl>
+               <ptr target="bm:Baxter2005Galla"/>
+            </bibl>            
+         </listBibl>
       </body>
    </text>
 </TEI>

--- a/Ethnic/ETH2043sanqel.xml
+++ b/Ethnic/ETH2043sanqel.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Šanqǝlla</title>
+            <title>Šānqǝllā (outdated idiom)</title>
             <author/>
          </titleStmt>
          <publicationStmt>
@@ -36,20 +36,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="PL" when="2016-10-18"> Created file from google
                                 spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: ethnic</change>
+         <change when="2024-09-17" who="CH">Updated name and added bibliography.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPerson>
             <personGrp role="ethnic">
-               <persName xml:id="n1">
-                  <orgName>Šanqǝlla</orgName>
-               </persName>
-               <persName xml:id="n2">
-                  <orgName>Šanqalla, Šanqilla, Šǝnqǝlla</orgName>
-               </persName>
+               <persName xml:id="n1" xml:lang="gez" type="main"><orgName>ሻንቅላ፡</orgName></persName>
+               <persName corresp="#n1" type="normalized" xml:lang="gez"><orgName>Šānqǝllā</orgName></persName>
+               <persName xml:id="n2" xml:lang="gez"><orgName>ሻንቀላ፡</orgName></persName>
+               <persName corresp="#n2" type="normalized" xml:lang="gez"><orgName>Šānqallā</orgName></persName>
+               <persName xml:id="n3" xml:lang="gez"><orgName>ሻንቂላ፡</orgName></persName>
+               <persName corresp="#n3" type="normalized" xml:lang="gez"><orgName>Šānqillā</orgName></persName>
+               <persName xml:id="n4" xml:lang="gez"><orgName>ሽንቅላ፡</orgName></persName>
+               <persName corresp="#n4" type="normalized" xml:lang="gez"><orgName>Šǝnqǝllā</orgName></persName>
             </personGrp>
          </listPerson>
+         <listBibl type="secondary">
+            <bibl>
+               <ptr target="bm:Smidt2010Sanqella"/>
+            </bibl>            
+         </listBibl>
       </body>
    </text>
 </TEI>


### PR DESCRIPTION
I wanted to add some information in an abstract, but I have seen, that there is no option to add an abstract to any PRS or ETH record. It would be possible to add information in <occupation> or <floruit>, but this seemed to be not suitable for a discussion of the term, which I intended and outlined in https://github.com/BetaMasaheft/Documentation/issues/2637. 
For this reason, I refrained from that and limited myself with small updates of the bibliographies and transcriptions in each of the records.