### PR TITLE
Minor updates PRS records Yoḥannǝs (2x) and Tewodros II

### DIFF
--- a/PRS10001-11000/PRS10393Yohanne.xml
+++ b/PRS10001-11000/PRS10393Yohanne.xml
@@ -52,9 +52,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <persName xml:lang="gez" xml:id="n1" type="birth">ዮሐንስ፡</persName>
                <persName xml:lang="gez" corresp="#n1" type="normalized">Yoḥannǝs III</persName>
                <persName>
-                  <roleName type="title">ʾAbuna</roleName>
+                  <roleName type="title">ʾabuna</roleName>
                </persName>
-               <occupation type="ecclesiastic">Metropolitan</occupation>
+               <occupation type="ecclesiastic">metropolitan</occupation>
                <nationality type="Egypt"/>
                <faith type="Coptic"/>
              

--- a/PRS13001-14000/PRS13526Yohannes.xml
+++ b/PRS13001-14000/PRS13526Yohannes.xml
@@ -53,8 +53,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <faith type="Christianity"/>
                     <birth/>
                     <death/>
-                    <floruit>Under this name is preserved a rare homily on Mary preserved in <ref type="mss" corresp="EMML1763"/> and
-                    <ref type="mss" corresp="EMML8897"/>.</floruit>
+                    <floruit>Under this name is preserved a rare homily on Mary preserved in <ref type="mss" corresp="EMML1763">EMML no. 1763</ref> and
+                    <ref type="mss" corresp="EMML8897">EMML no. 8897</ref>.</floruit>
                 </person>
                 <listRelation>
                     <relation name="saws:isAttributedToAuthor" active="PRS13526Yohannes" passive="LIT6493Dersan"/>

--- a/PRS9001-10000/PRS9430Tewodros.xml
+++ b/PRS9001-10000/PRS9430Tewodros.xml
@@ -48,7 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <listPerson>
             <person sex="1" sameAs="wd:Q262589">
                <persName xml:id="n1" xml:lang="gez" type="regnal">ቴዎድሮስ፡</persName>
-               <persName xml:lang="gez" corresp="#n1" type="normalized">Tewodros <addName>II</addName></persName>
+               <persName xml:lang="gez" corresp="#n1" type="normalized">Tewodros II</persName>
                <persName xml:lang="en" corresp="#n1">Theodore</persName>
                <persName xml:lang="gez" xml:id="n2" type="birth">ካሣ፡ ኃይሉ፡</persName>
                <persName xml:lang="gez" corresp="#n2" type="normalized">Kāśā Ḫāylu</persName>


### PR DESCRIPTION
I made some minor updates to three records:

Titles in PRS10393Yohanne, because I think we used to write all titles and occupations in PRS records non-capitalized.

I wrote the EMML nos. in the tags, because the manuscripts are not properly displayed, as can be seen below:

<img width="749" height="143" alt="grafik" src="https://github.com/user-attachments/assets/d04d713e-3642-4c79-925b-986a74894da1" />


I deleted addName in PRS9430Tewodros, because otherwise 'II' does not appear in the title and in the search results, as can be seen below:

<img width="881" height="415" alt="grafik" src="https://github.com/user-attachments/assets/dbd8e3ae-8ee9-43a5-9a78-93a16f56215b" />
