### PR TITLE
Up bishops in BLorient12913J

### DIFF
--- a/PRS6001-7000/PRS6772Marqos.xml
+++ b/PRS6001-7000/PRS6772Marqos.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Marqos</title>
+            <title>Mārqos</title>
             <author/>
          </titleStmt>
          <publicationStmt>
@@ -32,29 +32,31 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
       </profileDesc>
       <revisionDesc>
          <change who="PL" when="2016-04-28">batch updated according to requirements and issues.</change>
          <change who="PL" when="2016-03-21"> Created file from
                                                   google spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: person</change>
+         <change when="2025-09-18" who="CH">Updated names, occupation, floruit; added bibliography</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPerson>
             <person sex="1">
-               <persName>
-                  
-                  Marqos
-               </persName>
-               <occupation> bishop (Goǧǧam) </occupation>
-               <residence>
-                  Gojjam
-               </residence>
+               <persName xml:lang="gez" xml:id="n1" type="monastic">ማርቆስ፡</persName>
+               <persName xml:lang="gez" corresp="#n1" type="normalized">Mārqos</persName>
+               <occupation type="ecclesiastic">bishop of <placeName ref="LOC3549Gojjam"/></occupation>
+               <residence ref="LOC2310DabraM"/>
+               <faith type="EOTC"/>
+               <floruit notBefore="1900" notAfter="1999">20th century</floruit>
             </person>
          </listPerson>
+         <listBibl type="secondary">
+            <bibl><ptr target="bm:Nosnitsin2005Eppisqoppos"/><citedRange unit="page">344a</citedRange></bibl>
+         </listBibl>
       </body>
    </text>
 </TEI>

--- a/PRS7001-8000/PRS7822Petros.xml
+++ b/PRS7001-8000/PRS7822Petros.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>Ṗeṭros</title>
+            <title>P̣eṭros</title>
             <author/>
          </titleStmt>
          <publicationStmt>
@@ -32,28 +32,34 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
       </profileDesc>
       <revisionDesc>
          <change who="PL" when="2016-04-28">batch updated according to requirements and issues.</change>
          <change who="PL" when="2016-03-21"> Created file from
                                                   google spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: person</change>
+         <change when="2025-09-18" who="CH">Updated names, occupation, birth and death; added bibliography</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPerson>
             <person sex="1">
-               <persName>
-                  
-                  Ṗeṭros
-               </persName>
-               <persName type="alt">Mäḥari Tǝrfe</persName>
-               <occupation> bishop</occupation>
-               <death>d. 1968</death>
+               <persName xml:id="n1" xml:lang="gez" type="monastic">ጴጥሮስ፡</persName>
+               <persName corresp="#n1" xml:lang="gez" type="normalized">P̣eṭros</persName>
+               <persName xml:id="n2" xml:lang="gez" type="birth">መሐሪ፡ ትርፌ፡</persName>
+               <persName corresp="#n2" xml:lang="gez" type="normalized">Maḥari Tǝrfe</persName>
+               <occupation type="ecclesiastic">bishop of <placeName ref="LOC5671Semen"/> and <placeName ref="LOC1713Bagemd"/>.</occupation>
+               <residence ref="LOC3577Gondar"/>
+               <faith type="EOTC"/>
+               <birth when="1908-08-12">12 August 1908</birth>
+               <death when="1968-07-06">6 July 1968</death>
             </person>
          </listPerson>
+         <listBibl type="secondary">
+            <bibl><ptr target="bm:Mersha2010Petros"/></bibl>
+         </listBibl>
       </body>
    </text>
 </TEI>

--- a/PRS7001-8000/PRS7822Petros.xml
+++ b/PRS7001-8000/PRS7822Petros.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title>P̣eṭros</title>
+            <title>Ṗeṭros</title>
             <author/>
          </titleStmt>
          <publicationStmt>
@@ -47,7 +47,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <listPerson>
             <person sex="1">
                <persName xml:id="n1" xml:lang="gez" type="monastic">ጴጥሮስ፡</persName>
-               <persName corresp="#n1" xml:lang="gez" type="normalized">P̣eṭros</persName>
+               <persName corresp="#n1" xml:lang="gez" type="normalized">Ṗeṭros</persName>
                <persName xml:id="n2" xml:lang="gez" type="birth">መሐሪ፡ ትርፌ፡</persName>
                <persName corresp="#n2" xml:lang="gez" type="normalized">Maḥari Tǝrfe</persName>
                <occupation type="ecclesiastic">bishop of <placeName ref="LOC5671Semen"/> and <placeName ref="LOC1713Bagemd"/>.</occupation>


### PR DESCRIPTION
I updated the records of two bishops of the 20th century attested in BLorient12913J.

I was confused about the transcription of ጵ . Personally, I prefer ̣Pṗ, but here I found Ṗ (ṗ), but in the EAe, there is ̣P ̣̣p ̣. Do we have any straight rule? The Guidelines do not give an answer to this question in the [Transliteration Principles](https://betamasaheft.eu/Guidelines/?q=transcription&start=6&id=transliteration-principles).